### PR TITLE
Enforcing OpenGL 3.3 Core Profile.

### DIFF
--- a/hypercube.cabal
+++ b/hypercube.cabal
@@ -27,6 +27,7 @@ library
     , lens
     , stm
     , OpenGL
+    , OpenGLRaw
     , linear
     , vector
     , containers
@@ -41,6 +42,7 @@ library
       Hypercube.Chunk
       Hypercube.Chunk.Faces
       Hypercube.Config
+      Hypercube.Error
       Hypercube.Game
       Hypercube.Input
       Hypercube.Shaders

--- a/src/Hypercube/Chunk.hs
+++ b/src/Hypercube/Chunk.hs
@@ -73,7 +73,7 @@ newChunk :: V3 Int -> IO Chunk
 newChunk pos = do
   --putStrLn ("newChunk: " ++ show pos)
   let blk = V.generate (chunkSize ^ (3 :: Int)) (generatingF . (+ chunkSize *^ pos) . fromPos)
-  blk `deepseq` return (Chunk blk undefined 0 True)
+  blk `deepseq` return (Chunk blk undefined undefined 0 True)
 
 updateChunk :: V3 Int -> StateT Chunk IO ()
 updateChunk pos = do
@@ -139,8 +139,8 @@ extractSurface blk
       face d & traverse +~ (0 & _xyz .~ fmap fromIntegral v 
                               & _w   .~ if d `elem` [Top,Bottom] then 0 else 1)
 
-renderChunk :: V3 Int -> UniformLocation -> StateT Chunk IO ()
-renderChunk pos modelLoc = do
+renderChunkTheOldWay :: V3 Int -> UniformLocation -> StateT Chunk IO ()
+renderChunkTheOldWay pos modelLoc = do
   --isChanged <- use chunkChanged
   --when isChanged (updateChunk pos)
   n <- use chunkElements
@@ -158,4 +158,17 @@ renderChunk pos modelLoc = do
       drawArrays Triangles 0 $ fromIntegral n
       vertexAttribArray (AttribLocation 0) $= Disabled
 
+renderChunk :: V3 Int -> UniformLocation -> StateT Chunk IO ()
+renderChunk pos modelLoc = do
+  --isChanged <- use chunkChanged
+  --when isChanged (updateChunk pos)
+  n <- use chunkElements
+  when (n > 0) $ do
+    use chunkVao >>= (bindVertexArrayObject $=) . Just
+    liftIO $ do
+      model <- toGLmatrix $ identity & translation +~
+        (fromIntegral <$> chunkSize *^ pos)
+      uniform modelLoc $= model
+
+      drawArrays Triangles 0 $ fromIntegral n
 

--- a/src/Hypercube/Error.hs
+++ b/src/Hypercube/Error.hs
@@ -1,0 +1,30 @@
+module Hypercube.Error (
+    printErrors
+) where
+
+import Control.Monad
+import qualified Graphics.GL as Raw
+
+getErrors :: IO [Raw.GLuint]
+getErrors = do
+    error <- Raw.glGetError
+    if error == Raw.GL_NO_ERROR
+        then return []
+        else (error:) <$> getErrors
+
+showError :: Raw.GLuint-> String
+showError error = case error of
+    Raw.GL_INVALID_ENUM -> "GL_INVALID_ENUM"
+    Raw.GL_INVALID_VALUE -> "GL_INVALID_VALUE"
+    Raw.GL_INVALID_OPERATION -> "GL_INVALID_OPERATION"
+    Raw.GL_INVALID_FRAMEBUFFER_OPERATION -> "GL_INVALID_FRAMEBUFFER_OPERATION"
+    Raw.GL_OUT_OF_MEMORY -> "GL_OUT_OF_MEMORY"
+    Raw.GL_STACK_UNDERFLOW -> "GL_STACK_UNDERFLOW"
+    Raw.GL_STACK_OVERFLOW -> "GL_STACK_OVERFLOW"
+    x -> "GL Error " ++ show x
+
+printErrors :: String -> IO ()
+printErrors prefix = do
+    es <- map showError <$> getErrors
+    unless (null es) $
+        error (prefix ++ ": " ++ show es)

--- a/src/Hypercube/Error.hs
+++ b/src/Hypercube/Error.hs
@@ -3,24 +3,24 @@ module Hypercube.Error (
 ) where
 
 import Control.Monad
-import qualified Graphics.GL as Raw
+import Graphics.GL
 
-getErrors :: IO [Raw.GLuint]
+getErrors :: IO [GLuint]
 getErrors = do
-    error <- Raw.glGetError
-    if error == Raw.GL_NO_ERROR
+    error <- glGetError
+    if error == GL_NO_ERROR
         then return []
         else (error:) <$> getErrors
 
-showError :: Raw.GLuint-> String
+showError :: GLuint-> String
 showError error = case error of
-    Raw.GL_INVALID_ENUM -> "GL_INVALID_ENUM"
-    Raw.GL_INVALID_VALUE -> "GL_INVALID_VALUE"
-    Raw.GL_INVALID_OPERATION -> "GL_INVALID_OPERATION"
-    Raw.GL_INVALID_FRAMEBUFFER_OPERATION -> "GL_INVALID_FRAMEBUFFER_OPERATION"
-    Raw.GL_OUT_OF_MEMORY -> "GL_OUT_OF_MEMORY"
-    Raw.GL_STACK_UNDERFLOW -> "GL_STACK_UNDERFLOW"
-    Raw.GL_STACK_OVERFLOW -> "GL_STACK_OVERFLOW"
+    GL_INVALID_ENUM -> "GL_INVALID_ENUM"
+    GL_INVALID_VALUE -> "GL_INVALID_VALUE"
+    GL_INVALID_OPERATION -> "GL_INVALID_OPERATION"
+    GL_INVALID_FRAMEBUFFER_OPERATION -> "GL_INVALID_FRAMEBUFFER_OPERATION"
+    GL_OUT_OF_MEMORY -> "GL_OUT_OF_MEMORY"
+    GL_STACK_UNDERFLOW -> "GL_STACK_UNDERFLOW"
+    GL_STACK_OVERFLOW -> "GL_STACK_OVERFLOW"
     x -> "GL Error " ++ show x
 
 printErrors :: String -> IO ()

--- a/src/Hypercube/Game.hs
+++ b/src/Hypercube/Game.hs
@@ -21,6 +21,7 @@ import Hypercube.Config
 import Hypercube.Util
 import Hypercube.Shaders
 import Hypercube.Input
+import Hypercube.Error
 
 import qualified Debug.Trace as D
 
@@ -31,6 +32,7 @@ import Control.Lens
 import Control.Concurrent
 import Control.Exception
 import Data.Maybe
+import Foreign.Ptr
 import qualified Graphics.Rendering.OpenGL as GL
 import qualified Graphics.GLUtil as U
 import Graphics.UI.GLFW as GLFW
@@ -210,25 +212,40 @@ mainLoop win todo chan viewLoc projLoc modelLoc = do
         loadVbos = do
           -- TODO: better timeout estimate (calculate time left until next frame)
           t <- liftIO $ (+ 0.001) . fromJust <$> GLFW.getTime
-          liftIO (atomically (tryReadTChan chan)) >>= maybe (return ()) (\(pos,Chunk blk _ _ _,v) -> do
+          liftIO (atomically (tryReadTChan chan)) >>= maybe (return ()) (\(pos,Chunk blk _ _ _ _,v) -> do
             m <- use world
             if pos `M.member` m then
               loadVbos
             else do
               let len = VS.length v
+              vao <- GL.genObjectName
+              GL.bindVertexArrayObject GL.$= Just vao
+
               vbo <- GL.genObjectName
               liftIO $ when (len > 0) $ do
                 GL.bindBuffer GL.ArrayBuffer GL.$= Just vbo
                 VS.unsafeWith v $ \ptr ->
                   GL.bufferData GL.ArrayBuffer GL.$= 
                     (CPtrdiff (fromIntegral (sizeOf (undefined :: V4 Int8) * len)), ptr, GL.StaticDraw)
+
+                -- Associate the VAO with the data of the VBO.
+                -- The VBO doesn't need to be bound later when using the VAO.
+                GL.vertexAttribPointer (GL.AttribLocation 0) GL.$=
+                  (GL.KeepIntegral, GL.VertexArrayDescriptor 4 GL.Byte 0 (intPtrToPtr 0))
+                GL.vertexAttribArray (GL.AttribLocation 0) GL.$= GL.Enabled
+                
                 GL.bindBuffer GL.ArrayBuffer GL.$= Nothing
-              world %= M.insert pos (Chunk blk vbo len False)
+
+              GL.bindVertexArrayObject GL.$= Nothing
+
+              world %= M.insert pos (Chunk blk vbo vao len False)
               t' <- liftIO $ fromJust <$> GLFW.getTime
               when (t' < t) loadVbos)
       loadVbos
 
+    liftIO $ printErrors "At the start of the loop"
     draw height width curGaze (proj !*! view) modelLoc todo
+    liftIO $ printErrors "At the end of the loop"
 
     liftIO $ GLFW.swapBuffers win
 

--- a/src/Hypercube/Types.hs
+++ b/src/Hypercube/Types.hs
@@ -72,7 +72,8 @@ instance NFData Block where
 data Chunk
   = Chunk
   { _chunkBlk      :: !(V.Vector Block)
-  , _chunkVbo      :: GL.BufferObject
+  , _chunkVbo      :: GL.BufferObject -- ^ No need to keep it around.
+  , _chunkVao      :: GL.VertexArrayObject
   , _chunkElements :: !Int
   , _chunkChanged  :: !Bool
   }

--- a/src/Hypercube/Util.hs
+++ b/src/Hypercube/Util.hs
@@ -23,6 +23,12 @@ withWindow width height title f = do
   GLFW.setErrorCallback $ Just simpleErrorCallback
   r <- GLFW.init
   when r $ do
+    mapM_ GLFW.windowHint
+      [   GLFW.WindowHint'Samples 4 -- 4x antialiasing
+      ,   GLFW.WindowHint'ContextVersionMajor 3
+      ,   GLFW.WindowHint'ContextVersionMinor 3
+      ,   GLFW.WindowHint'OpenGLProfile GLFW.OpenGLProfile'Core -- OpenGL 3.3 Core Profile (or better)
+      ]
     m <- GLFW.createWindow width height title Nothing Nothing
     case m of
       Nothing -> return ()


### PR DESCRIPTION
I've made some small changes to your project in order to be able to run it at home. I'm pretty sure it would have worked _as is_ on my old GeForce 660 with the proprietary driver, but it is not the case on my new RX 470 with the free AMDGPU driver. This one has a poor legacy mode support and forces me to use core profiles to unlock modern OpenGL features. Not a bad thing it itself, but it imply to introduce VAO in your code in place of a deprecated direct VBO usage.